### PR TITLE
Use Xcode 15.4 on CI

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -60,7 +60,7 @@ runs:
     - uses: maxim-lobanov/setup-xcode@v1
       if: ${{ inputs.ios == 'true' }}
       with:
-        xcode-version: '14.3'
+        xcode-version: '15.4'
 
     - name: Install dependencies
       if: ${{ inputs.ios == 'true' || inputs.brew == 'true' }}


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Xcode 15.4 is recommended now for using the Bitmovin Player SDK.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Using Xcode 15.4 on CI now.

## Checklist
- [ ] 🗒 `CHANGELOG` entry - internal change only
