### PR TITLE
Update iOS Conviva integration to version 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Updated the Bitmovin Player Conviva Analytics Integration for iOS dependency to `3.3.2`.
+
 ## [1.1.0] - 2024-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ source 'https://github.com/bitmovin/cocoapod-specs.git'
 The the following line to your desired target:
 
 ```ruby
-pod 'BitmovinConvivaAnalytics', git: 'https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git', tag: '3.3.0'
+pod 'BitmovinConvivaAnalytics', git: 'https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git', tag: '3.3.2'
 ```
 
 Then, in your command line run in your `ios` folder:

--- a/bitmovin-player-react-native-analytics-conviva.podspec
+++ b/bitmovin-player-react-native-analytics-conviva.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     :git => "https://github.com/bitmovin/bitmovin-player-react-native-analytics-conviva.git",
     :tag => "#{s.version}"
   }
-  s.dependency "BitmovinConvivaAnalytics" # 3.3.0 or newer
+  s.dependency "BitmovinConvivaAnalytics" # 3.3.2 or newer
   s.dependency "RNBitmovinPlayer"
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -28,7 +28,7 @@ def setup os
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod "BitmovinConvivaAnalytics", git: "https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git", tag: "3.3.0"
+  pod "BitmovinConvivaAnalytics", git: "https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git", tag: "3.3.2"
 end
 
 target 'BitmovinPlayerReactNativeAnalyticsConvivaExample' do

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -26,7 +26,7 @@ PODS:
     - BitmovinAnalyticsCollector/Core
     - BitmovinPlayerCore (~> 3.48)
   - BitmovinAnalyticsCollector/Core (3.7.0)
-  - BitmovinConvivaAnalytics (3.3.0):
+  - BitmovinConvivaAnalytics (3.3.2):
     - BitmovinPlayer (~> 3.64)
     - ConvivaSDK (~> 4.0)
   - BitmovinPlayer (3.66.1):
@@ -1186,7 +1186,7 @@ PODS:
 
 DEPENDENCIES:
   - bitmovin-player-react-native-analytics-conviva (from `../..`)
-  - BitmovinConvivaAnalytics (from `https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git`, tag `3.3.0`)
+  - BitmovinConvivaAnalytics (from `https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git`, tag `3.3.2`)
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
@@ -1260,7 +1260,7 @@ EXTERNAL SOURCES:
     :path: "../.."
   BitmovinConvivaAnalytics:
     :git: https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git
-    :tag: 3.3.0
+    :tag: 3.3.2
   boost:
     :podspec: "../node_modules/react-native/third-party-podspecs/boost.podspec"
   DoubleConversion:
@@ -1374,12 +1374,12 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   BitmovinConvivaAnalytics:
     :git: https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git
-    :tag: 3.3.0
+    :tag: 3.3.2
 
 SPEC CHECKSUMS:
   bitmovin-player-react-native-analytics-conviva: 58284765258c3e2223fe7c52a843632e0acd8a66
   BitmovinAnalyticsCollector: bbd82c0b8e11aefacd8e53b6e40c62f2cba6f3f5
-  BitmovinConvivaAnalytics: 263a2f7aee931eb1aa6274bf997ab7453d580c4a
+  BitmovinConvivaAnalytics: efb80945c4f01c977b12b6ff5b2d4a1168fd132d
   BitmovinPlayer: 0d5990c196eff314b7081c49ed481e9d465d7281
   BitmovinPlayerCore: f6f8b8655bece7c8e9daccc49cc55642212d9c2f
   boost: 88202336c3ba1e7a264a83c0c888784b0f360c28
@@ -1439,8 +1439,8 @@ SPEC CHECKSUMS:
   ReactCommon: 678c6fdb479e7533859f29000d899af37d3a6c7a
   RNBitmovinPlayer: 57b3b5672e59031080ce43928f3c1f2275eaec00
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: d84d1e521e3f8fa3cdd139d617ddf6514d061c78
+  Yoga: bb33480fd76c5cb82ef4ba27c49276abfdd692d1
 
-PODFILE CHECKSUM: f3eb1c4b0a98d1f6673aaee3005ffb38ccbec67d
+PODFILE CHECKSUM: afac6349ff0a4b82bbc00d809d7b699ce74cd4a7
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
There is a new `3.3.2` release for the Bitmovin iOS Player Conviva integration.
See [here](https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva/releases/tag/3.3.2).

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Updated the dependency to version `3.3.2`.

## Checklist
- [x] 🗒 `CHANGELOG` entry
