### PR TITLE
Add support for late attaching player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Updated the `bitmovin-player-react-native` dependency to `0.28.0`.
 - Updated the Bitmovin Player Conviva Analytics Integration for iOS dependency to `3.4.1`.
+- Updated the Bitmovin Player Conviva Analytics Integration for Android dependency to `2.6.0`.
 
 ## [1.2.0] - 2024-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Changed
 
 - Updated the `bitmovin-player-react-native` dependency to `0.28.0`.
-- Updated the Bitmovin Player Conviva Analytics Integration for iOS dependency to `3.4.0`.
+- Updated the Bitmovin Player Conviva Analytics Integration for iOS dependency to `3.4.1`.
 
 ## [1.2.0] - 2024-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Possibility to start session tracking without a `Player` instance
+  - `ConvivaAnalytics({ customerKey, config })` without a `Player`
+  - `ConvivaAnalytics.attachPlayer(player)` to attach the `Player` at a later point in the session life-cycle
+
+### Changed
+
+- Updated the `bitmovin-player-react-native` dependency to `0.28.0`.
+- Updated the Bitmovin Player Conviva Analytics Integration for iOS dependency to `3.4.0`.
+
 ## [1.2.0] - 2024-07-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -215,3 +215,43 @@ If you want to use the same player instance for multiple playback, just load a n
 ```ts
 player.load(…);
 ```
+
+### External VST tracking
+
+If your app needs additional setup steps which should be included in VST tracking, such as DRM token generation, before the `Player` instance can be initialized,
+the `ConvivaAnalytics` can be initialized without a `Player` instance. Once the `Player` instance is created it can be attached.
+
+1. Create the `ConvivaAnalytics` instance with your `customerKey`.
+
+```ts
+const convivaAnalytics = useConvivaAnalytics({
+  customerKey: 'YOUR-CONVIVA-CUSTOMER-KEY',
+});
+
+const onConvivaSetupError = useCallback((error) => {
+  console.error('Conviva error', error);
+}, []);
+
+// Initialize ConvivaAnalytics
+convivaAnalytics.initialize().catch(onConvivaSetupError);
+```
+
+2. Conviva requires that the `assetName` is set at session initialization. Therefore ensure that you provide using the `ConvivaAnalytics.updateContentMetadata()` **before** initializing the tracking session.
+
+```ts
+convivaAnalytics.updateContentMetadata({
+  assetName: 'Your Asset Name',
+});
+
+// Initialize tracking session
+convivaAnalytics.initializeSession();
+```
+
+3. Once your `Player` instance is ready attach it to the `ConvivaAnalytics` instance.
+
+```ts
+// ... Additional setup steps
+
+const player = usePlayer();
+convivaAnalytics.attachPlayer(player);
+```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -103,7 +103,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'com.conviva.sdk:conviva-core-sdk:4.0.37'
-  implementation 'com.bitmovin.analytics:conviva:2.5.0'
+  implementation 'com.bitmovin.analytics:conviva:2.6.0'
   implementation project(':bitmovin-player-react-native')
   implementation 'com.bitmovin.player:player:3.74.0+jason' // must be the same version as in bitmovin-player-react-native
 }

--- a/bitmovin-player-react-native-analytics-conviva.podspec
+++ b/bitmovin-player-react-native-analytics-conviva.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     :git => "https://github.com/bitmovin/bitmovin-player-react-native-analytics-conviva.git",
     :tag => "#{s.version}"
   }
-  s.dependency "BitmovinConvivaAnalytics" # 3.3.2 or newer
+  s.dependency "BitmovinConvivaAnalytics" # 3.4.0 or newer
   s.dependency "RNBitmovinPlayer"
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"

--- a/bitmovin-player-react-native-analytics-conviva.podspec
+++ b/bitmovin-player-react-native-analytics-conviva.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     :git => "https://github.com/bitmovin/bitmovin-player-react-native-analytics-conviva.git",
     :tag => "#{s.version}"
   }
-  s.dependency "BitmovinConvivaAnalytics" # 3.4.0 or newer
+  s.dependency "BitmovinConvivaAnalytics" # 3.4.1 or newer
   s.dependency "RNBitmovinPlayer"
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"

--- a/example/ios/BitmovinPlayerReactNativeAnalyticsConvivaExample.xcodeproj/project.pbxproj
+++ b/example/ios/BitmovinPlayerReactNativeAnalyticsConvivaExample.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "BitmovinPlayerReactNativeAnalyticsConvivaExample" */;
 			buildPhases = (
 				C38B50BA6285516D6DCD4F65 /* [CP] Check Pods Manifest.lock */,
+				A8C1881B2C7CBBCA00CDE6CA /* SwiftLint */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
@@ -346,6 +347,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-BitmovinPlayerReactNativeAnalyticsConvivaExample-tvOS/Pods-BitmovinPlayerReactNativeAnalyticsConvivaExample-tvOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A8C1881B2C7CBBCA00CDE6CA /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\n(\n  cd ../../\n  if which swiftlint > /dev/null; then\n    swiftlint\n  else\n    echo \"warning: SwiftLint not installed, run \\`brew bundle install\\` in project root to install\"\n  fi\n)\n";
 			showEnvVarsInLog = 0;
 		};
 		A8F972072C0F1C2300AE7340 /* Bundle React Native code and images */ = {
@@ -564,10 +585,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				TVOS_DEPLOYMENT_TARGET = 14.0;
@@ -640,10 +658,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				TVOS_DEPLOYMENT_TARGET = 14.0;

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -28,7 +28,7 @@ def setup os
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod "BitmovinConvivaAnalytics", git: "https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git", tag: "3.3.2"
+  pod "BitmovinConvivaAnalytics", git: "https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git", tag: "3.4.0"
 end
 
 target 'BitmovinPlayerReactNativeAnalyticsConvivaExample' do

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -28,7 +28,7 @@ def setup os
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod "BitmovinConvivaAnalytics", git: "https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git", tag: "3.4.0"
+  pod "BitmovinConvivaAnalytics", git: "https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git", tag: "3.4.1"
 end
 
 target 'BitmovinPlayerReactNativeAnalyticsConvivaExample' do

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -26,13 +26,13 @@ PODS:
     - BitmovinAnalyticsCollector/Core
     - BitmovinPlayerCore (~> 3.48)
   - BitmovinAnalyticsCollector/Core (3.7.0)
-  - BitmovinConvivaAnalytics (3.3.2):
+  - BitmovinConvivaAnalytics (3.4.0):
     - BitmovinPlayer (~> 3.64)
     - ConvivaSDK (~> 4.0)
-  - BitmovinPlayer (3.66.1):
+  - BitmovinPlayer (3.67.0):
     - BitmovinAnalyticsCollector/BitmovinPlayer (~> 3.0)
-    - BitmovinPlayerCore (= 3.66.1)
-  - BitmovinPlayerCore (3.66.1)
+    - BitmovinPlayerCore (= 3.67.0)
+  - BitmovinPlayerCore (3.67.0)
   - boost (1.83.0)
   - ConvivaSDK (4.0.49)
   - DoubleConversion (1.1.6)
@@ -1176,8 +1176,8 @@ PODS:
     - React-logger (= 0.74.1-0)
     - React-perflogger (= 0.74.1-0)
     - React-utils (= 0.74.1-0)
-  - RNBitmovinPlayer (0.27.1):
-    - BitmovinPlayer (= 3.66.1)
+  - RNBitmovinPlayer (0.28.0):
+    - BitmovinPlayer (= 3.67.0)
     - GoogleAds-IMA-iOS-SDK (= 3.23.0)
     - GoogleAds-IMA-tvOS-SDK (= 4.13.0)
     - React-Core
@@ -1186,7 +1186,7 @@ PODS:
 
 DEPENDENCIES:
   - bitmovin-player-react-native-analytics-conviva (from `../..`)
-  - BitmovinConvivaAnalytics (from `https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git`, tag `3.3.2`)
+  - BitmovinConvivaAnalytics (from `https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git`, tag `3.4.0`)
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
@@ -1260,7 +1260,7 @@ EXTERNAL SOURCES:
     :path: "../.."
   BitmovinConvivaAnalytics:
     :git: https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git
-    :tag: 3.3.2
+    :tag: 3.4.0
   boost:
     :podspec: "../node_modules/react-native/third-party-podspecs/boost.podspec"
   DoubleConversion:
@@ -1374,14 +1374,14 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   BitmovinConvivaAnalytics:
     :git: https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git
-    :tag: 3.3.2
+    :tag: 3.4.0
 
 SPEC CHECKSUMS:
   bitmovin-player-react-native-analytics-conviva: 09fb79f45e2294ce339c7d0ee03b00a187a03075
   BitmovinAnalyticsCollector: bbd82c0b8e11aefacd8e53b6e40c62f2cba6f3f5
-  BitmovinConvivaAnalytics: efb80945c4f01c977b12b6ff5b2d4a1168fd132d
-  BitmovinPlayer: 0d5990c196eff314b7081c49ed481e9d465d7281
-  BitmovinPlayerCore: f6f8b8655bece7c8e9daccc49cc55642212d9c2f
+  BitmovinConvivaAnalytics: fdb459a33e7151d8fc26c736d16f7efb52aad5a5
+  BitmovinPlayer: 48ee17de9e0bbd310d874112bab92cb78f5e1cbf
+  BitmovinPlayerCore: da464f49a91a1308519a7187088822e33f1d057b
   boost: 88202336c3ba1e7a264a83c0c888784b0f360c28
   ConvivaSDK: 5d10811e8611ed1fd99a5ab291bdcb1e795f8756
   DoubleConversion: 00143ab27d470b28035933623e1a3ea37e68889c
@@ -1437,10 +1437,10 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 4780cdba710de22aae5ea6769266cec9a89b2bba
   React-utils: 45e9ba5a0ec387d31de5d24043bdcf7915b9658b
   ReactCommon: 678c6fdb479e7533859f29000d899af37d3a6c7a
-  RNBitmovinPlayer: 57b3b5672e59031080ce43928f3c1f2275eaec00
+  RNBitmovinPlayer: ae4f785479c566a71bf03d84bde7ec139eb22eaa
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: d84d1e521e3f8fa3cdd139d617ddf6514d061c78
+  Yoga: bb33480fd76c5cb82ef4ba27c49276abfdd692d1
 
-PODFILE CHECKSUM: afac6349ff0a4b82bbc00d809d7b699ce74cd4a7
+PODFILE CHECKSUM: 4e5689986b30951dcf432aef14ca8e81c3a4202a
 
 COCOAPODS: 1.15.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -26,7 +26,7 @@ PODS:
     - BitmovinAnalyticsCollector/Core
     - BitmovinPlayerCore (~> 3.48)
   - BitmovinAnalyticsCollector/Core (3.7.0)
-  - BitmovinConvivaAnalytics (3.4.0):
+  - BitmovinConvivaAnalytics (3.4.1):
     - BitmovinPlayer (~> 3.64)
     - ConvivaSDK (~> 4.0)
   - BitmovinPlayer (3.67.0):
@@ -1186,7 +1186,7 @@ PODS:
 
 DEPENDENCIES:
   - bitmovin-player-react-native-analytics-conviva (from `../..`)
-  - BitmovinConvivaAnalytics (from `https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git`, tag `3.4.0`)
+  - BitmovinConvivaAnalytics (from `https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git`, tag `3.4.1`)
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
@@ -1260,7 +1260,7 @@ EXTERNAL SOURCES:
     :path: "../.."
   BitmovinConvivaAnalytics:
     :git: https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git
-    :tag: 3.4.0
+    :tag: 3.4.1
   boost:
     :podspec: "../node_modules/react-native/third-party-podspecs/boost.podspec"
   DoubleConversion:
@@ -1374,12 +1374,12 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   BitmovinConvivaAnalytics:
     :git: https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git
-    :tag: 3.4.0
+    :tag: 3.4.1
 
 SPEC CHECKSUMS:
   bitmovin-player-react-native-analytics-conviva: 09fb79f45e2294ce339c7d0ee03b00a187a03075
   BitmovinAnalyticsCollector: bbd82c0b8e11aefacd8e53b6e40c62f2cba6f3f5
-  BitmovinConvivaAnalytics: fdb459a33e7151d8fc26c736d16f7efb52aad5a5
+  BitmovinConvivaAnalytics: 88938e0b343392c4036b122e635b47745dd8af80
   BitmovinPlayer: 48ee17de9e0bbd310d874112bab92cb78f5e1cbf
   BitmovinPlayerCore: da464f49a91a1308519a7187088822e33f1d057b
   boost: 88202336c3ba1e7a264a83c0c888784b0f360c28
@@ -1441,6 +1441,6 @@ SPEC CHECKSUMS:
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: bb33480fd76c5cb82ef4ba27c49276abfdd692d1
 
-PODFILE CHECKSUM: 4e5689986b30951dcf432aef14ca8e81c3a4202a
+PODFILE CHECKSUM: 9c82995f06bb5aa4bbd4829cfffe8dbd5623929b
 
 COCOAPODS: 1.15.2

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
     "pods-update": "NO_FLIPPER=1 pod update --silent --project-directory=ios"
   },
   "dependencies": {
-    "bitmovin-player-react-native": "^0.27.1",
+    "bitmovin-player-react-native": "^0.28.0",
     "react": "18.2.0",
     "react-native": "npm:react-native-tvos@0.74.1-0"
   },

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -271,7 +271,7 @@ export default function App() {
               assetUrlRef.current = text;
             }}
           />
-          <View style={styles.buttonContainer}>
+          <View style={styles.buttonRowContainer}>
             <Button
               title="Setup"
               onPress={() => {
@@ -280,12 +280,16 @@ export default function App() {
             />
             <Button title="Release" onPress={release} />
           </View>
-          <View style={styles.buttonContainer}>
+          <View style={styles.buttonRowContainer}>
             <Button title="Pause tracking" onPress={pauseTracking} />
             <Button title="Resume Tracking" onPress={resumeTracking} />
           </View>
-          <Button title="Send custom event" onPress={sendCustomEvent} />
-          <Button title="Start session" onPress={startSession} />
+          <View style={styles.buttonContainer}>
+            <Button title="Send custom event" onPress={sendCustomEvent} />
+          </View>
+          <View style={styles.buttonContainer}>
+            <Button title="Start session" onPress={startSession} />
+          </View>
         </>
       )}
     </Container>
@@ -320,8 +324,13 @@ const styles = StyleSheet.create({
     marginBottom: 16,
     paddingHorizontal: 8,
   },
-  buttonContainer: {
+  buttonRowContainer: {
     flexDirection: 'row',
+    justifyContent: 'space-between',
+    width: '100%',
+    marginBottom: 16,
+  },
+  buttonContainer: {
     justifyContent: 'space-between',
     width: '100%',
     marginBottom: 16,

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -88,32 +88,55 @@ export default function App() {
     []
   );
 
-  const [player, setPlayer] = useState(createPlayer());
+  const [player, _setPlayer] = useState<Player | undefined>(createPlayer());
+  const setPlayer = useCallback(
+    (newPlayer: Player | undefined) => {
+      playerRef.current = newPlayer;
+      _setPlayer((prevPlayer) => {
+        prevPlayer?.destroy();
+        return newPlayer;
+      });
+    },
+    [_setPlayer]
+  );
+  const playerRef = useRef<Player | undefined>(player);
 
-  const createConvivaAnalytics = useCallback(async () => {
-    const convivaAnalytics = new ConvivaAnalytics({
-      player: player,
-      customerKey: CONVIVA_CUSTOMER_KEY,
-      debugLoggingEnabled: true,
-      gatewayUrl: CONVIVA_GATEWAY_URL,
-    });
-    await convivaAnalytics.initialize();
-    convivaAnalytics.updateContentMetadata({
-      applicationName: 'Bitmovin iOS Conviva integration example app',
-      viewerId: 'awesomeViewerId',
-      custom: { custom_tag: 'Episode' },
-      additionalStandardTags: { 'c3.cm.contentType': 'VOD' },
-    });
-    return convivaAnalytics;
-  }, [player]);
-
-  const [convivaAnalytics, setConvivaAnalytics] = useState<
+  const [convivaAnalytics, _setConvivaAnalytics] = useState<
     ConvivaAnalytics | undefined
   >(undefined);
+  const convivaAnalyticsRef = useRef<ConvivaAnalytics | undefined>(
+    convivaAnalytics
+  );
+  const setConvivaAnalytics = useCallback(
+    (newConvivaAnalytics: ConvivaAnalytics | undefined) => {
+      convivaAnalyticsRef.current = newConvivaAnalytics;
+      _setConvivaAnalytics(newConvivaAnalytics);
+    },
+    [_setConvivaAnalytics]
+  );
+
+  const createConvivaAnalytics =
+    useCallback(async (): Promise<ConvivaAnalytics> => {
+      if (convivaAnalyticsRef.current !== undefined) {
+        if (playerRef.current !== undefined) {
+          convivaAnalyticsRef.current.attachPlayer(playerRef.current as any);
+        }
+        return convivaAnalyticsRef.current;
+      } else {
+        const newConvivaAnalytics = new ConvivaAnalytics({
+          player: playerRef.current as any,
+          customerKey: CONVIVA_CUSTOMER_KEY,
+          debugLoggingEnabled: true,
+          gatewayUrl: CONVIVA_GATEWAY_URL,
+        });
+        await newConvivaAnalytics.initialize();
+        return newConvivaAnalytics;
+      }
+    }, []);
 
   const loadAsset = useCallback(
     (url: string) =>
-      player.load({
+      player?.load({
         url: url,
         type: SourceType.HLS,
         title: 'Art of Motion',
@@ -122,16 +145,16 @@ export default function App() {
   );
 
   const setupPlayer = useCallback(() => {
-    setPlayer((prevPlayer) => {
-      prevPlayer.destroy();
-      return createPlayer();
-    });
-  }, [createPlayer]);
+    setPlayer(createPlayer());
+  }, [createPlayer, setPlayer]);
 
   const release = useCallback(() => {
     convivaAnalytics?.release();
-    player.unload();
-  }, [player, convivaAnalytics]);
+    setConvivaAnalytics(undefined);
+    player?.unload();
+    player?.destroy();
+    setPlayer(undefined);
+  }, [player, convivaAnalytics, setConvivaAnalytics, setPlayer]);
 
   const pauseTracking = useCallback(() => {
     convivaAnalytics?.pauseTracking(false);
@@ -142,23 +165,32 @@ export default function App() {
   }, [convivaAnalytics]);
 
   const sendCustomEvent = useCallback(async () => {
-    const playerCurrentTime = await player.getCurrentTime();
+    const playerCurrentTime = await player?.getCurrentTime();
     convivaAnalytics?.sendCustomPlaybackEvent('Custom Event', {
-      'at Time': `${Math.floor(playerCurrentTime)}`,
+      'at Time': playerCurrentTime ? `${Math.floor(playerCurrentTime)}` : 'NA',
     });
   }, [convivaAnalytics, player]);
 
   useEffect(() => {
+    if (player === undefined) {
+      return;
+    }
     const urlToLoad =
       assetUrlRef.current !== undefined && validator.isURL(assetUrlRef.current)
         ? assetUrlRef.current
         : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8';
 
     createConvivaAnalytics().then((newConvivaAnalytics) => {
+      newConvivaAnalytics.updateContentMetadata({
+        applicationName: 'Bitmovin iOS Conviva integration example app',
+        viewerId: 'awesomeViewerId',
+        custom: { custom_tag: 'Episode' },
+        additionalStandardTags: { 'c3.cm.contentType': 'VOD' },
+      });
       setConvivaAnalytics(newConvivaAnalytics);
       loadAsset(urlToLoad);
     });
-  }, [createConvivaAnalytics, loadAsset]);
+  }, [createConvivaAnalytics, loadAsset, player, setConvivaAnalytics]);
 
   const [adsEnabled, setAdsEnabled] = useState(true);
 
@@ -203,15 +235,28 @@ export default function App() {
     }
   }, [convivaAnalytics]);
 
+  const startSession = useCallback(() => {
+    setConvivaAnalytics(undefined);
+    createConvivaAnalytics().then((newConvivaAnalytics) => {
+      newConvivaAnalytics.updateContentMetadata({
+        assetName: 'Art of Motion',
+      });
+      newConvivaAnalytics.initializeSession();
+      setConvivaAnalytics(newConvivaAnalytics);
+    });
+  }, [createConvivaAnalytics, setConvivaAnalytics]);
+
   const Container = Platform.isTV ? View : SafeAreaView;
 
   return (
     <Container style={styles.container}>
-      <PlayerView
-        style={styles.player}
-        player={player}
-        viewRef={playerViewRef}
-      />
+      {(player && (
+        <PlayerView
+          style={styles.player}
+          player={player}
+          viewRef={playerViewRef}
+        />
+      )) || <View style={styles.player} />}
       {!Platform.isTV && (
         <>
           <View style={styles.adControlContainer}>
@@ -240,6 +285,7 @@ export default function App() {
             <Button title="Resume Tracking" onPress={resumeTracking} />
           </View>
           <Button title="Send custom event" onPress={sendCustomEvent} />
+          <Button title="Start session" onPress={startSession} />
         </>
       )}
     </Container>
@@ -256,6 +302,7 @@ const styles = StyleSheet.create({
   player: {
     aspectRatio: 16 / 9,
     backgroundColor: 'black',
+    width: '100%',
   },
   adControlContainer: {
     flexDirection: 'row',

--- a/ios/BitmovinPlayerReactNativeAnalyticsConviva.mm
+++ b/ios/BitmovinPlayerReactNativeAnalyticsConviva.mm
@@ -8,8 +8,15 @@ RCT_EXTERN_METHOD(initWithConfig:(NSString *)nativeId
              debugLoggingEnabled:(BOOL)debugLoggingEnabled
                         resolver:(RCTPromiseResolveBlock)resolve
                         rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(attachPlayer:(NSString *)nativeId
+                  playerNativeId:(NSString *)playerNativeId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(destroy:(NSString *)nativeId)
 RCT_EXTERN_METHOD(release:(NSString *)nativeId)
+RCT_EXTERN_METHOD(initializeSession:(NSString *)nativeId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(endSession:(NSString *)nativeId)
 RCT_EXTERN_METHOD(setPlayerViewRef:(NSString *)nativeId playerViewRefId:(nonnull NSNumber *)playerViewRefId)
 RCT_EXTERN_METHOD(resetPlayerViewRef:(NSString *)nativeId)

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@react-native/eslint-config": "^0.73.1",
     "@types/jest": "^29.5.5",
     "@types/react": "^18.2.44",
-    "bitmovin-player-react-native": "0.27.1",
+    "bitmovin-player-react-native": "^0.25.0",
     "del-cli": "^5.1.0",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",

--- a/src/convivaAnalytics.ts
+++ b/src/convivaAnalytics.ts
@@ -45,13 +45,13 @@ export class ConvivaAnalytics extends NativeInstance<ConvivaAnalyticsConfig> {
   /**
    * Initializes a new conviva tracking session.
    *
-   *  @warning The integration can only be validated without external session managing. So when using this method we can
-   *  no longer ensure that the session is managed at the correct time. Additional: Since some metadata attributes
-   *  rely on the player's source we can't ensure that all metadata attributes are present at session creation.
-   *  Therefore it is possible that we receive a 'ContentMetadata created late' issue after conviva validation.
+   * @warning The integration can only be validated without external session managing. So when using this method we can
+   * no longer ensure that the session is managed at the correct time. Additional: Since some metadata attributes
+   * rely on the player's source we can't ensure that all metadata attributes are present at session creation.
+   * Therefore it is possible that we receive a 'ContentMetadata created late' issue after conviva validation.
    *
-   *  If no source was loaded (or the itemTitle is missing) and no assetName was set via updateContentMetadata
-   *  this method will throw an error.
+   * If no source was loaded (or the itemTitle is missing) and no assetName was set via updateContentMetadata
+   * this method will throw an error.
    *
    * @returns promise which resolves when the conviva tracking session is sucessfully initialized.
    *

--- a/src/convivaAnalytics.ts
+++ b/src/convivaAnalytics.ts
@@ -4,6 +4,7 @@ import { Platform, NativeModules, findNodeHandle } from 'react-native';
 import NativeInstance from './nativeInstance';
 import type { ConvivaAnalyticsConfig } from './convivaAnalyticsConfig';
 import { SsaiApi } from './ssaiApi';
+import type { Player } from 'bitmovin-player-react-native';
 
 const { BitmovinPlayerReactNativeAnalyticsConviva } = NativeModules;
 
@@ -34,7 +35,7 @@ export class ConvivaAnalytics extends NativeInstance<ConvivaAnalyticsConfig> {
     this.isInitialized = true;
     return BitmovinPlayerReactNativeAnalyticsConviva.initWithConfig(
       this.nativeId,
-      this.config?.player.nativeId,
+      this.config?.player?.nativeId,
       this.config?.customerKey,
       this.config?.gatewayUrl,
       this.config?.debugLoggingEnabled ?? false
@@ -42,14 +43,53 @@ export class ConvivaAnalytics extends NativeInstance<ConvivaAnalyticsConfig> {
   };
 
   /**
+   * Initializes a new conviva tracking session.
+   *
+   *  @warning The integration can only be validated without external session managing. So when using this method we can
+   *  no longer ensure that the session is managed at the correct time. Additional: Since some metadata attributes
+   *  rely on the player's source we can't ensure that all metadata attributes are present at session creation.
+   *  Therefore it is possible that we receive a 'ContentMetadata created late' issue after conviva validation.
+   *
+   *  If no source was loaded (or the itemTitle is missing) and no assetName was set via updateContentMetadata
+   *  this method will throw an error.
+   *
+   * @returns promise which resolves when the conviva tracking session is sucessfully initialized.
+   *
+   * @platform Android, iOS, tvOS
+   */
+  initializeSession = async (): Promise<void> => {
+    return BitmovinPlayerReactNativeAnalyticsConviva.initializeSession(
+      this.nativeId
+    );
+  };
+
+  /**
+   * Attaches the given player to the conviva analytics.
+   * This method should be called as soon as the `Player` instance is initialized to not miss any tracking.
+   *
+   * @warning Has no effect if there is already a {@link Player} instance set. Use the {@link ConvivaAnalyticsConfig} without `player` if you plan to attach a `Player` instance later in the life-cycle.
+   *
+   * @param player The player which should be attached to the conviva analytics.
+   * @returns promise which resolves when the player is sucessfully attached to the conviva analytics.
+   *
+   * @platform Android, iOS, tvOS
+   */
+  attachPlayer = async (player: Player): Promise<void> => {
+    return BitmovinPlayerReactNativeAnalyticsConviva.attachPlayer(
+      this.nativeId,
+      player.nativeId
+    );
+  };
+
+  /**
    * Destroys the native `ConvivaAnalytics` and releases all of its allocated resources.
    */
-  destroy(): void {
+  destroy = () => {
     if (!this.isDestroyed) {
       BitmovinPlayerReactNativeAnalyticsConviva.destroy(this.nativeId);
       this.isDestroyed = true;
     }
-  }
+  };
 
   /**
    * Releases the conviva analytics.

--- a/src/convivaAnalyticsConfig.ts
+++ b/src/convivaAnalyticsConfig.ts
@@ -7,8 +7,10 @@ import type { NativeInstanceConfig } from './nativeInstance';
 export interface ConvivaAnalyticsConfig extends NativeInstanceConfig {
   /**
    * The player instance which will be used for tracking.
+   * When not set at initialization, {@link ConvivaAnalytics.initializeSession} must be called after creating the {@link ConvivaAnalytics} instance.
+   * The player instance can be set later via the {@link ConvivaAnalytics.attachPlayer} method.
    */
-  player: Player;
+  player?: Player;
   /**
    * The customer key which will be used for tracking.
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3672,7 +3672,7 @@ __metadata:
     "@react-native/typescript-config": 0.74.83
     "@types/validator": ^13.11.10
     babel-plugin-module-resolver: ^5.0.0
-    bitmovin-player-react-native: ^0.27.1
+    bitmovin-player-react-native: ^0.28.0
     pod-install: ^0.1.0
     react: 18.2.0
     react-native: "npm:react-native-tvos@0.74.1-0"
@@ -3687,7 +3687,7 @@ __metadata:
     "@react-native/eslint-config": ^0.73.1
     "@types/jest": ^29.5.5
     "@types/react": ^18.2.44
-    bitmovin-player-react-native: 0.27.1
+    bitmovin-player-react-native: ^0.25.0
     del-cli: ^5.1.0
     eslint: ^8.51.0
     eslint-config-prettier: ^9.0.0
@@ -3707,15 +3707,27 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"bitmovin-player-react-native@npm:0.27.1, bitmovin-player-react-native@npm:^0.27.1":
-  version: 0.27.1
-  resolution: "bitmovin-player-react-native@npm:0.27.1"
+"bitmovin-player-react-native@npm:^0.25.0":
+  version: 0.25.0
+  resolution: "bitmovin-player-react-native@npm:0.25.0"
   dependencies:
     lodash.omit: 4.5.0
   peerDependencies:
     react: ">=17"
     react-native: ">=0.65"
-  checksum: 9721578d739e0cadcd3bdd3a6833e0a988d824c954d746f39ef7c2afd679d793960d848f5e834e8b3ee31772a85a0b9b1cb08e5368c7eb43e2a61f97e9990127
+  checksum: 4468e1e0763bd9c9ef9eddbf8ec8fdb93d348b80eab59b68f1ec5f0b09e837150fe403d78ddcf9d97eb5cb5ad65a3c9021eaec5a869bb31fe5e7d2fedfb6cef8
+  languageName: node
+  linkType: hard
+
+"bitmovin-player-react-native@npm:^0.28.0":
+  version: 0.28.0
+  resolution: "bitmovin-player-react-native@npm:0.28.0"
+  dependencies:
+    lodash.omit: 4.5.0
+  peerDependencies:
+    react: ">=17"
+    react-native: ">=0.65"
+  checksum: 2ff27f161621e78aecaad8dd53ffa51e9152d1ef282d58103eda3d648eba773bb79351c0b4d4b14afd5f995d142666b59f2397cc4dc410badf79ff9f4e36bfeb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
There are certain scenarios where VST tracking should start before a Player instance is created. Currently there is no way to start a Conviva Session without a player instance.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Extending the API to allow session initialization without a Player instance and adding a possibility to attach a Player instance at a later point in the life-cycle of the session.

### Manual testing instructions
I extended the Sample with a new `Start session` button. To test this, start the sample but first hit the `Release` button to stop and destroy the player/session, which automatically starts.
- Tap `Start Session` button
- Tap `Setup` button
- Double check in touchstone that the duration between those two actions is properly tracked as VST.

## Checklist
- [x] 🗒 `CHANGELOG` entry
