### PR TITLE
Migrate Akamai CDN URLs to Bitmovin CDN

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -178,7 +178,7 @@ export default function App() {
     const urlToLoad =
       assetUrlRef.current !== undefined && validator.isURL(assetUrlRef.current)
         ? assetUrlRef.current
-        : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8';
+        : 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8';
 
     createConvivaAnalytics().then((newConvivaAnalytics) => {
       newConvivaAnalytics.updateContentMetadata({


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
We are moving away from Akamai CDN in favor of Bitmovin CDN.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Updated URLs to use the same assets from the Bitmovin CDN.

## Checklist
- [ ] 🗒 `CHANGELOG` entry - not needed
